### PR TITLE
last-term parser fix

### DIFF
--- a/node-ner.js
+++ b/node-ner.js
@@ -82,6 +82,17 @@ ner.prototype.parse = function(parsed, callback) {
 		prevEntity = tagged[i].t;
 	}
 	
+	// Check entityBuffer one last time to make sure we account for the last term
+	if (entityBuffer.length>0) {
+		// There was! We save the entity
+		if (!entities.hasOwnProperty(prevEntity)) {
+			entities[prevEntity] = [];
+		}
+		entities[prevEntity].push(entityBuffer.join(' '));
+		// Now we set the buffer
+		entityBuffer = [];
+	}
+	
 	
 	callback(entities);
 }


### PR DESCRIPTION
Problem: Last term from the java output won't be returned in the JSON when it is tagged as something different than 'O', it stays in the entityBuffer.

Fix: Added a last entityBuffer check to the parser in order to make sure no terms get forgotten there.

Note: Sorry about the newline at the end, not sure why it shows up if none of the versions have a new line there, I know the formatting is important so I didn't even touch there.